### PR TITLE
Some errors in "Curve::RemoveKnot()"

### DIFF
--- a/src/LNLib/Geometry/Curve/NurbsCurve.cpp
+++ b/src/LNLib/Geometry/Curve/NurbsCurve.cpp
@@ -606,19 +606,22 @@ bool LNLib::NurbsCurve::RemoveKnot(const LN_NurbsCurve& curve, double removeKnot
 			}
 		}
 
-		if (remflag)
+		if (!remflag)
 		{
-			i = first;
-			j = last;
-
-			while (j - i > t)
-			{
-				updatedControlPoints[i] = temp[i - off];
-				updatedControlPoints[j] = temp[j - off];
-				i = i + 1;
-				j = j - 1;
-			}
+			break;
 		}
+
+		i = first;
+		j = last;
+
+		while (j - i > t)
+		{
+			updatedControlPoints[i] = temp[i - off];
+			updatedControlPoints[j] = temp[j - off];
+			i = i + 1;
+			j = j - 1;
+		}
+
 		first = first - 1;
 		last = last + 1;
 	}

--- a/src/LNLib/Geometry/Curve/NurbsCurve.cpp
+++ b/src/LNLib/Geometry/Curve/NurbsCurve.cpp
@@ -600,7 +600,7 @@ bool LNLib::NurbsCurve::RemoveKnot(const LN_NurbsCurve& curve, double removeKnot
 		else
 		{
 			double alphai = (removeKnot - knotVector[i]) / (knotVector[i + order + t] - knotVector[i]);
-			if (MathUtils::IsLessThanOrEqual(controlPoints[i].Distance(alphai * temp[ii + t + 1] + (1.0 * alphai) * temp[ii - 1]), tol))
+			if (MathUtils::IsLessThanOrEqual(controlPoints[i].Distance(alphai * temp[ii + t + 1] + (1.0 - alphai) * temp[ii - 1]), tol))
 			{
 				remflag = true;
 			}


### PR DESCRIPTION

In [Geometry/Curve/NurbsCurve.cpp#L603](https://github.com/BIMCoderLiang/LNLib/blob/6ad96c6a4c0e59a6475fcbaf7b8b78b4c69a3367/src/LNLib/Geometry/Curve/NurbsCurve.cpp#L603)

```c++
if (MathUtils::IsLessThanOrEqual(controlPoints[i].Distance(alphai * temp[ii + t + 1] + (1.0 * alphai) * temp[ii - 1]), tol))
```

The coefficient `(1.0 * alphai)` doesn't make sense, accroing to _The NURBS book 2nd_, it should be `(1.0 - alphai)`.


The for loop should exit when remFlag equals false, accroing to _The NURBS book 2nd_. The current implementation does not do this.

