### PR TITLE
fixed Simpson area computation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 
 # Folder
 .vs/
+.vscode/
 
 src/x64
 test/x64

--- a/src/LNLib/Algorithm/Integrator.cpp
+++ b/src/LNLib/Algorithm/Integrator.cpp
@@ -24,20 +24,41 @@ namespace LNLib
         double result = ((end - start) / 6.0) * (st + 4 * mt + et);
         return result;
     }
-    double Integrator::Simpson(double start, double end, std::vector<double> odds, std::vector<double> evens, double delta)
+
+	double Integrator::Simpson(BinaryIntegrationFunction& function, void* customData, 
+				double u1, double u2, double v1, double v2)
 	{
-		double oddsSum = 0.0;
-		double evensSum = 0.0;
-		for (int i = 0; i < odds.size(); i++)
-		{
-			oddsSum += 4 * odds[i];
-		}
-		for (int i = 0; i < evens.size(); i++)
-		{
-			evensSum += 2 * evens[i];
-		}
-		double result = (delta / 3.0) * (start + oddsSum + evensSum + end);
-		return result;
+        double du = u2 - u1;
+        double dv = v2 - v1;
+        double hdu = 0.5 * du;
+        double hdv = 0.5 * dv;
+		
+        // Sample 9 points with weights
+        double uvw[] = {
+            u1,       v1,       1,
+            u1,       v1 + hdv, 4,
+            u1,       v2,       1,
+            u1 + hdu, v1,       4,
+            u1 + hdu, v1 + hdv, 16,
+            u1 + hdu, v2,       4,
+            u2,       v1,       1,
+            u2,       v1 + hdv, 4,
+            u2,       v2,       1,
+            };
+        
+        double sum = 0;
+        for(int i=0;i<9;++i)
+        {
+            double* base = uvw + i*3;
+            double u = base[0];
+            double v = base[1];
+            double w = base[2];
+            double f = function(u, v, customData);
+            sum += w * f;
+        }
+
+        sum *= du * dv / 36;
+        return sum;
 	}
 
     const std::vector<double> Integrator::GaussLegendreAbscissae =

--- a/src/LNLib/Geometry/Surface/NurbsSurface.cpp
+++ b/src/LNLib/Geometry/Surface/NurbsSurface.cpp
@@ -2813,47 +2813,89 @@ double LNLib::NurbsSurface::ApproximateArea(const LN_NurbsSurface& surface, Inte
 	{
 		case IntegratorType::Simpson:
 		{
-			double halfV = (startV + endV) / 2.0;
-			XYZ halfStart = GetPointOnSurface(reSurface, UV(startU, halfV));
-			XYZ halfEnd = GetPointOnSurface(reSurface, UV(endU, halfV));
-
-			double totalWidth = halfStart.Distance(halfEnd);
-			int num = 20;
-			double delta = totalWidth / (num - 1);
-
-			XYZ start1 = GetPointOnSurface(reSurface, UV(startU, startV));
-			XYZ start2 = GetPointOnSurface(reSurface, UV(startU, endV));
-			double startLength = start1.Distance(start2);
-
-			std::vector<double> odds;
-			std::vector<double> evens;
-
-			XYZ dir = (halfEnd - halfStart).Normalize();
-
-			for (int i = 1; i < num; i++)
+			struct fun
+			:public BinaryIntegrationFunction
 			{
-				XYZ current = halfStart + dir * delta * i;
-				UV uv = GetParamOnSurface(reSurface, current);
-				double u = uv.GetU();
-				XYZ point1 = GetPointOnSurface(reSurface, UV(u, startV));
-				XYZ point2 = GetPointOnSurface(reSurface, UV(u, endV));
-				double length = point1.Distance(point2);
-
-				if (i % 2 == 0)
+				virtual double operator()(double u, double v, void* customData)const override
 				{
-					evens.emplace_back(length);
+					auto surface = (LN_NurbsSurface*)customData;
+					auto der = NurbsSurface::ComputeRationalSurfaceDerivatives(*surface, 1, UV(u, v));
+					const XYZ& Su = der[1][0];
+					const XYZ& Sv = der[0][1];
+					double E = Su.DotProduct(Su);
+					double F = Su.DotProduct(Sv);
+					double G = Sv.DotProduct(Sv);
+					double ds = std::sqrt(E * G - F * F);
+					return ds;
+				}
+			}function;
+
+			// the initial search range
+			struct UVA
+			{
+				double u1, u2, v1, v2;
+				double area;
+			};
+			UVA init;
+			init.u1 = 0;
+			init.u2 = 1;
+			init.v1 = 0;
+			init.v2 = 1;
+			init.area = Integrator::Simpson(function, (void*)&reSurface, init.u1, init.u2, init.v1, init.v2);
+			std::vector<UVA> stack(1, init);
+
+			while(!stack.empty())
+			{
+				UVA uva = stack.back();
+				stack.pop_back();
+
+				// Bisect uv into 4 parts.
+				double du = uva.u2 - uva.u1;
+				double dv = uva.v2 - uva.v1;
+				double hdu = 0.5 * du;
+				double hdv = 0.5 * dv;
+				UVA uva1, uva2, uva3, uva4;
+				uva1.u1 = uva.u1;
+				uva1.u2 = uva.u1 + hdu;
+				uva1.v1 = uva.v1;
+				uva1.v2 = uva.v1 + hdv;
+				uva1.area = Integrator::Simpson(function, (void*)&reSurface, uva1.u1, uva1.u2, uva1.v1, uva1.v2);
+				uva2.u1 = uva.u1 + hdu;
+				uva2.u2 = uva.u2;
+				uva2.v1 = uva.v1;
+				uva2.v2 = uva.v1 + hdv;
+				uva2.area = Integrator::Simpson(function, (void*)&reSurface, uva2.u1, uva2.u2, uva2.v1, uva2.v2);
+				uva3.u1 = uva.u1;
+				uva3.u2 = uva.u1 + hdu;
+				uva3.v1 = uva.v1 + hdv;
+				uva3.v2 = uva.v2;
+				uva3.area = Integrator::Simpson(function, (void*)&reSurface, uva3.u1, uva3.u2, uva3.v1, uva3.v2);
+				uva4.u1 = uva.u1 + hdu;
+				uva4.u2 = uva.u2;
+				uva4.v1 = uva.v1 + hdv;
+				uva4.v2 = uva.v2;
+				uva4.area = Integrator::Simpson(function, (void*)&reSurface, uva4.u1, uva4.u2, uva4.v1, uva4.v2);
+
+				// sum area
+				double areaNew = uva1.area + uva2.area + uva3.area + uva4.area;
+
+				// The error is tolerated.
+				// fixMe: The tolerance can be a parameter, Gauss and Chebyshev should handle it too.
+				if(std::fabs(areaNew - uva.area) < 1e-4)
+				{
+					// Accumulate to the final area.
+					area += areaNew;
 				}
 				else
 				{
-					odds.emplace_back(length);
+					// Continue bisections.
+					stack.push_back(uva1);
+					stack.push_back(uva2);
+					stack.push_back(uva3);
+					stack.push_back(uva4);
 				}
 			}
 
-			XYZ end1 = GetPointOnSurface(reSurface, UV(endU, startV));
-			XYZ end2 = GetPointOnSurface(reSurface, UV(endU, endV));
-			double endLength = end1.Distance(end2);
-
-			area = Integrator::Simpson(startLength, endLength, odds, evens, delta);
 			break;
 		}
 		case IntegratorType::GaussLegendre:

--- a/src/LNLib/Geometry/Surface/NurbsSurface.cpp
+++ b/src/LNLib/Geometry/Surface/NurbsSurface.cpp
@@ -119,26 +119,13 @@ LNLib::XYZ LNLib::NurbsSurface::GetPointOnSurface(const LN_NurbsSurface& surface
 
 std::vector<std::vector<LNLib::XYZ>> LNLib::NurbsSurface::ComputeRationalSurfaceDerivatives(const LN_NurbsSurface& surface, int derivative, UV uv)
 {
-	int degreeU = surface.DegreeU;
-	int degreeV = surface.DegreeV;
-	std::vector<double> knotVectorU = surface.KnotVectorU;
-	std::vector<double> knotVectorV = surface.KnotVectorV;
-	std::vector<std::vector<XYZW>> controlPoints = surface.ControlPoints;
-
 	VALIDATE_ARGUMENT(derivative > 0, "derivative", "derivative must greater than zero.");
-	VALIDATE_ARGUMENT_RANGE(uv.GetU(), knotVectorU[0], knotVectorU[knotVectorU.size() - 1]);
-	VALIDATE_ARGUMENT_RANGE(uv.GetV(), knotVectorV[0], knotVectorV[knotVectorV.size() - 1]);
+	VALIDATE_ARGUMENT_RANGE(uv.GetU(), surface.KnotVectorU[0], surface.KnotVectorU.back());
+	VALIDATE_ARGUMENT_RANGE(uv.GetV(), surface.KnotVectorV[0], surface.KnotVectorV.back());
 
 	std::vector<std::vector<XYZ>> derivatives(derivative + 1, std::vector<XYZ>(derivative + 1));
 
-	LN_BsplineSurface<XYZW> bsplineSurface;
-	bsplineSurface.DegreeU = degreeU;
-	bsplineSurface.DegreeV = degreeV;
-	bsplineSurface.KnotVectorU = knotVectorU;
-	bsplineSurface.KnotVectorV = knotVectorV;
-	bsplineSurface.ControlPoints = controlPoints;
-
-	std::vector<std::vector<XYZW>> ders = BsplineSurface::ComputeDerivatives(bsplineSurface, derivative, uv);
+	std::vector<std::vector<XYZW>> ders = BsplineSurface::ComputeDerivatives(surface, derivative, uv);
 	std::vector<std::vector<XYZ>> Aders(derivative + 1, std::vector<XYZ>(derivative + 1));
 	std::vector<std::vector<double>> wders(derivative + 1, std::vector<double>(derivative + 1));
 	for (int i = 0; i < ders.size(); i++)

--- a/src/LNLib/include/BsplineSurface.h
+++ b/src/LNLib/include/BsplineSurface.h
@@ -94,9 +94,9 @@ namespace LNLib
 		{
 			int degreeU = surface.DegreeU;
 			int degreeV = surface.DegreeV;
-			std::vector<double> knotVectorU = surface.KnotVectorU;
-			std::vector<double> knotVectorV = surface.KnotVectorV;
-			std::vector<std::vector<T>> controlPoints = surface.ControlPoints;
+			const std::vector<double>& knotVectorU = surface.KnotVectorU;
+			const std::vector<double>& knotVectorV = surface.KnotVectorV;
+			const std::vector<std::vector<T>>& controlPoints = surface.ControlPoints;
 
 			VALIDATE_ARGUMENT(derivative > 0, "derivative", "derivative must greater than zero.");	
 			VALIDATE_ARGUMENT_RANGE(uv.GetU(), knotVectorU[0], knotVectorU[knotVectorU.size() - 1]);

--- a/src/LNLib/include/Integrator.h
+++ b/src/LNLib/include/Integrator.h
@@ -21,12 +21,19 @@ namespace LNLib
 		virtual double operator()(double parameter, void* customData) = 0;
 	};
 
+	class LNLIB_EXPORT BinaryIntegrationFunction
+	{
+	public:
+		virtual double operator()(double u, double v, void* customData)const = 0;
+	};
+
 	class LNLIB_EXPORT Integrator
 	{
 
 	public:
 		static double Simpson(IntegrationFunction& function, void* customData, double start, double end);
-		static double Simpson(double start, double end, std::vector<double> odds, std::vector<double> evens, double delta);
+		static double Simpson(BinaryIntegrationFunction& function, void* customData, 
+			double u1, double u2, double v1, double v2);
 
 		/// <summary>
 		/// According to https://github.com/Pomax/bezierjs
@@ -42,6 +49,7 @@ namespace LNLib
 		static double ClenshawCurtisQuadrature(IntegrationFunction& function, void* customData, double start, double end, std::vector<double>& series, double epsilon = Constants::DistanceEpsilon);
 		static double ClenshawCurtisQuadrature2(IntegrationFunction& function, void* customData, double start, double end, std::vector<double> series, double epsilon = Constants::DistanceEpsilon);
 	};
+	
 }
 
 

--- a/tests/T_Additional.cpp
+++ b/tests/T_Additional.cpp
@@ -59,7 +59,7 @@ TEST(Test_Additional, All)
 	EXPECT_TRUE(MathUtils::IsAlmostEqualTo(arcParameters[2], 0.75));
 }
 
-TEST(Test_Additional, Area)
+static void NURBSSurfaceForAreaTest(LN_NurbsSurface& surface, double& standardArea)
 {
 	int degreeU = 3;
 	int degreeV = 3;
@@ -109,21 +109,40 @@ TEST(Test_Additional, Area)
 	controlPoints[5][4] = XYZW(43.3333333, 50, 0, 1);
 	controlPoints[5][5] = XYZW(50, 50, 0, 1);
 
-	LN_NurbsSurface surface;
 	surface.DegreeU = degreeU;
 	surface.DegreeV = degreeV;
 	surface.KnotVectorU = kvU;
 	surface.KnotVectorV = kvV;
 	surface.ControlPoints = controlPoints;
 
-	double standardArea = 4384.255895045;
+	standardArea = 4384.255895045;
+}
 
-	double simpson = NurbsSurface::ApproximateArea(surface, IntegratorType::Simpson);
-	double gaussLegendre = NurbsSurface::ApproximateArea(surface, IntegratorType::GaussLegendre);
-	double chebyshev = NurbsSurface::ApproximateArea(surface, IntegratorType::Chebyshev);
-	EXPECT_NEAR(simpson, standardArea, 1e-4);
-	EXPECT_TRUE(MathUtils::IsAlmostEqualTo(gaussLegendre, standardArea));
-	EXPECT_TRUE(MathUtils::IsAlmostEqualTo(chebyshev, standardArea));
+TEST(Test_Additional, Area_Simpson)
+{
+	LN_NurbsSurface surface;
+	double standardArea;
+	NURBSSurfaceForAreaTest(surface, standardArea);
+	double area = NurbsSurface::ApproximateArea(surface, IntegratorType::Simpson);
+	EXPECT_NEAR(area, standardArea, 1e-4);
+}
+
+TEST(Test_Additional, Area_GaussLegendre)
+{
+	LN_NurbsSurface surface;
+	double standardArea;
+	NURBSSurfaceForAreaTest(surface, standardArea);
+	double area = NurbsSurface::ApproximateArea(surface, IntegratorType::GaussLegendre);
+	EXPECT_NEAR(area, standardArea, 7e-5);
+}
+
+TEST(Test_Additional, Area_ChebyShev)
+{
+	LN_NurbsSurface surface;
+	double standardArea;
+	NURBSSurfaceForAreaTest(surface, standardArea);
+	double area = NurbsSurface::ApproximateArea(surface, IntegratorType::Chebyshev);
+	EXPECT_NEAR(area, standardArea, 2e-3);
 }
 
 TEST(Test_Additional, MergeCurve)

--- a/tests/T_Additional.cpp
+++ b/tests/T_Additional.cpp
@@ -121,7 +121,7 @@ TEST(Test_Additional, Area)
 	double simpson = NurbsSurface::ApproximateArea(surface, IntegratorType::Simpson);
 	double gaussLegendre = NurbsSurface::ApproximateArea(surface, IntegratorType::GaussLegendre);
 	double chebyshev = NurbsSurface::ApproximateArea(surface, IntegratorType::Chebyshev);
-	EXPECT_FALSE(MathUtils::IsAlmostEqualTo(simpson, standardArea)); // not accuracy when use Simpson
+	EXPECT_NEAR(simpson, standardArea, 1e-4);
 	EXPECT_TRUE(MathUtils::IsAlmostEqualTo(gaussLegendre, standardArea));
 	EXPECT_TRUE(MathUtils::IsAlmostEqualTo(chebyshev, standardArea));
 }


### PR DESCRIPTION
- fixed Simpson area computation
compared with the original code:
error 1000+(incorrect) -> 1e-4
time 900+ ms -> 300+ ms

- removed unnecessary copying in surface derivative evaluation
- added vscode folder to git-ignore
- break area test into 3, to compare performance of different methods