### PR TITLE
Fix: typo in BezierCurve.cs

### DIFF
--- a/dotnet/PInvoke/src/BezierCurve.cs
+++ b/dotnet/PInvoke/src/BezierCurve.cs
@@ -50,7 +50,7 @@ namespace LNLibSharp
             LNLIB_CAPI_DLL,
             EntryPoint = "LNLIB_BEZIERCUR_get_rational_point_on_curve_by_deCasteljau",
             CallingConvention = CallingConvention.Cdecl)]
-        public static extern XYZW GetRationalPoinGetRationalPointOnCurveByDeCasteljautOnCurveByBernstein(
+        public static extern XYZW GetRationalPointOnCurveByDeCasteljau(
             int degree,
             [In] XYZW[] controlPoints,
             int controlPointsCount,


### PR DESCRIPTION
Hi there seems to be a typo in BezierCurve.cs:

https://github.com/BIMCoderLiang/LNLib/blob/d1d3c57bf5b1fb111e3d85ab5ffb491339b0f43e/dotnet/PInvoke/src/BezierCurve.cs#L53

should be:
```cs
public static extern XYZW GetRationalPointOnCurveByDeCasteljau(...)
```