### PR TITLE
fix #57

### DIFF
--- a/src/LNLib/Geometry/Curve/NurbsCurve.cpp
+++ b/src/LNLib/Geometry/Curve/NurbsCurve.cpp
@@ -3758,12 +3758,18 @@ bool LNLib::NurbsCurve::IsArc(const LN_NurbsCurve& curve, LN_ArcInfo& arcInfo)
 
 double LNLib::NurbsCurve::ApproximateLength(const LN_NurbsCurve& curve, IntegratorType type)
 {
-	if (IsLinear(curve))
+	bool isLinear = IsLinear(curve);
+	if (isLinear)
 	{
 		std::vector<XYZW> controlPoints = curve.ControlPoints;
 		XYZ startPoint = controlPoints[0].ToXYZ(true);
 		XYZ endPoint = controlPoints[controlPoints.size() - 1].ToXYZ(true);
 		return startPoint.Distance(endPoint);
+	}
+
+	if (curve.Degree == 1 && !isLinear)
+	{
+		VALIDATE_ARGUMENT(false, "curve", "Curve Degree is one but is not linear.");
 	}
 
 	LN_NurbsCurve reCurve;

--- a/tests/T_Additional.cpp
+++ b/tests/T_Additional.cpp
@@ -66,6 +66,18 @@ TEST(Test_Additional, ApproximateLength)
 	EXPECT_TRUE(MathUtils::IsAlmostEqualTo(arcParameters[2], 0.75));
 }
 
+TEST(Test_Additional, GetParamByLength)
+{
+	{
+		LN_NurbsCurve curve;
+		curve.Degree = 1;
+		curve.KnotVector = { 0,0,0.33333,0.666667,1.0,1.0 };
+		curve.ControlPoints = { {0,0,0,1},{5,1.438,0,1},{10,2.524,0,1},{15,2.992,0,1} };
+
+		ASSERT_THROW(NurbsCurve::GetParamOnCurve(curve, 14.4614, IntegratorType::GaussLegendre), std::invalid_argument);
+	}
+}
+
 TEST(Test_Additional, Normal)
 {
 	XYZ center = XYZ(0, 0, 0);


### PR DESCRIPTION
@antokhio Hello, I found when degree equals one will happen your issue.
The random data：degree = 1 and  control points is not linear, when use ``` ApproximateLength ``` will stuck in a loop.
You can see the tests for example.